### PR TITLE
add link to Tanay's Mamba Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # mamba-train
 
+<a target="_blank" href="https://lightning.ai/tanaymeh/studios/train-mamba-for-code-infilling-with-lance">
+  <img src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/app-2/studio-badge.svg" alt="Open In Studio"/>
+</a>
+
 A single repo with all scripts and utils to train / fine-tune the Mamba model with or without Fill-in-Middle objective (for code infilling).
 
 ### Data


### PR DESCRIPTION
Now you can create `Open in Studio` badge. This badge links to [your Studio template](https://lightning.ai/tanaymeh/studios/train-mamba-for-code-infilling-with-lance)

<img width="414" alt="image" src="https://github.com/tanaymeh/mamba-train/assets/21018714/d09b5ee1-582e-403e-9d2d-3643134df450">
